### PR TITLE
Fix RLS policy violation for profile creation during signup

### DIFF
--- a/client/lib/auth-context.tsx
+++ b/client/lib/auth-context.tsx
@@ -109,7 +109,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     if (data.user) {
       // Wait a bit for the session to be established
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
 
       // Get the current session to ensure we're authenticated
       const { data: sessionData } = await supabase.auth.getSession();
@@ -134,7 +134,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       } else {
         // No session available yet - email confirmation might be required
-        console.log("Email confirmation may be required. Profile will be created after confirmation.");
+        console.log(
+          "Email confirmation may be required. Profile will be created after confirmation.",
+        );
       }
     }
   };

--- a/client/lib/auth-context.tsx
+++ b/client/lib/auth-context.tsx
@@ -107,27 +107,35 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     if (error) throw error;
 
-    if (data.user && data.user.email_confirmed_at) {
-      // Only create profile if email is confirmed (immediate confirmation)
-      // For confirmed users, the session will be available immediately
-      const { error: profileError } = await supabase.from("profiles").insert({
-        id: data.user.id,
-        email: data.user.email!,
-        full_name: profileData.full_name!,
-        role: profileData.role || "student",
-        notification_preferences: {
-          email: true,
-          whatsapp: false,
-          telegram: false,
-        },
-      });
+    if (data.user) {
+      // Wait a bit for the session to be established
+      await new Promise(resolve => setTimeout(resolve, 1000));
 
-      if (profileError) throw profileError;
-    } else if (data.user && !data.user.email_confirmed_at) {
-      // If email confirmation is required, the profile will be created
-      // after email confirmation in the auth callback
-      // For now, we'll store the profile data temporarily in session
-      console.log("Email confirmation required. Profile will be created after confirmation.");
+      // Get the current session to ensure we're authenticated
+      const { data: sessionData } = await supabase.auth.getSession();
+
+      if (sessionData.session) {
+        // Session is available, create the profile
+        const { error: profileError } = await supabase.from("profiles").insert({
+          id: data.user.id,
+          email: data.user.email!,
+          full_name: profileData.full_name!,
+          role: profileData.role || "student",
+          notification_preferences: {
+            email: true,
+            whatsapp: false,
+            telegram: false,
+          },
+        });
+
+        if (profileError) {
+          console.error("Profile creation error:", profileError);
+          throw profileError;
+        }
+      } else {
+        // No session available yet - email confirmation might be required
+        console.log("Email confirmation may be required. Profile will be created after confirmation.");
+      }
     }
   };
 

--- a/client/pages/AuthCallback.tsx
+++ b/client/pages/AuthCallback.tsx
@@ -27,28 +27,23 @@ export default function AuthCallback() {
             .single();
 
           if (profileError && profileError.code === "PGRST116") {
-            // Profile doesn't exist, create it
+            // Profile doesn't exist, create it using INSERT
             const { error: createError } = await supabase
               .from("profiles")
-              .upsert(
-                {
-                  id: data.session.user.id,
-                  email: data.session.user.email!,
-                  full_name:
-                    data.session.user.user_metadata?.full_name ||
-                    data.session.user.user_metadata?.name ||
-                    "Google User",
-                  role: "student", // Default role for Google sign-ups
-                  notification_preferences: {
-                    email: true,
-                    whatsapp: false,
-                    telegram: false,
-                  },
+              .insert({
+                id: data.session.user.id,
+                email: data.session.user.email!,
+                full_name:
+                  data.session.user.user_metadata?.full_name ||
+                  data.session.user.user_metadata?.name ||
+                  "Google User",
+                role: "student", // Default role for Google sign-ups
+                notification_preferences: {
+                  email: true,
+                  whatsapp: false,
+                  telegram: false,
                 },
-                {
-                  onConflict: "id",
-                },
-              );
+              });
 
             if (createError) {
               console.error("Error creating profile:", createError);

--- a/supabase/migrations/002_fix_profiles_rls.sql
+++ b/supabase/migrations/002_fix_profiles_rls.sql
@@ -1,0 +1,39 @@
+-- Fix RLS policy for profiles table to handle signup edge cases
+-- This migration addresses the "new row violates row-level security policy" error
+
+-- Drop existing policies
+DROP POLICY IF EXISTS "Users can insert own profile" ON profiles;
+DROP POLICY IF EXISTS "Users can update own profile" ON profiles;
+DROP POLICY IF EXISTS "Users can view own profile" ON profiles;
+DROP POLICY IF EXISTS "Anyone can view organizer profiles" ON profiles;
+
+-- Recreate policies with better handling
+
+-- Allow users to view their own profile
+CREATE POLICY "Users can view own profile" ON profiles
+  FOR SELECT USING (auth.uid() = id);
+
+-- Allow users to update their own profile
+CREATE POLICY "Users can update own profile" ON profiles
+  FOR UPDATE USING (auth.uid() = id);
+
+-- Allow profile insertion during signup with proper authentication
+-- This policy allows insertion when the user is authenticated and the ID matches
+CREATE POLICY "Users can insert own profile during signup" ON profiles
+  FOR INSERT WITH CHECK (
+    auth.uid() = id 
+    AND auth.jwt() IS NOT NULL
+  );
+
+-- Public profiles for organizers (for viewing purposes)
+CREATE POLICY "Anyone can view organizer profiles" ON profiles
+  FOR SELECT USING (
+    role = 'organizer' AND 
+    id IN (SELECT user_id FROM organizers WHERE status = 'approved')
+  );
+
+-- Add a fallback policy for service role (for admin operations)
+CREATE POLICY "Service role can manage all profiles" ON profiles
+  FOR ALL USING (
+    auth.jwt()->>'role' = 'service_role'
+  );


### PR DESCRIPTION
## Purpose

The user encountered a "new row violates row-level security policy for table 'profiles'" error during user signup. This fix addresses the RLS policy violation by improving authentication handling and updating database policies to properly support profile creation during the signup process.

## Code changes

- **Authentication Context**: Added session validation with 1-second delay to ensure proper authentication state before profile creation, replaced `upsert` with `insert` for new profiles
- **Auth Callback**: Updated profile creation logic to use `insert` instead of `upsert` for better RLS compatibility
- **Database Migration**: Created new RLS policies that properly handle authenticated profile insertion during signup, including fallback policies for service role operations and improved authentication checks using `auth.jwt()`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2cdf8c60caf34f32a61b460658236476/nova-sanctuary)

👀 [Preview Link](https://2cdf8c60caf34f32a61b460658236476-nova-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2cdf8c60caf34f32a61b460658236476</projectId>-->
<!--<branchName>nova-sanctuary</branchName>-->